### PR TITLE
Adds events for watch-start and watch-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,18 @@ grunt.event.on('watch', function(action, filepath, target) {
 });
 ```
 
+Simple events are also available for 'watch-start' and 'watch-end'. These will fire before/after your watch tasks have run. Here is a simple example of using the `watch-start` and `watch-end` events.
+
+```js
+grunt.event.on('watch-start', function() {
+  grunt.log.writeln('Watch tasks are about to be run!');
+});
+
+grunt.event.on('watch-end', function() {
+  grunt.log.writeln('Watch tasks are finished running!');
+});
+```
+
 **The `watch` event is not intended for replacing the standard Grunt API for configuring and running tasks. If you're trying to run tasks from within the `watch` event you're more than likely doing it wrong. Please read [configuring tasks](http://gruntjs.com/configuring-tasks).**
 
 ##### Compiling Files As Needed

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -30,6 +30,10 @@ module.exports = function(grunt) {
 
   // When task runner has started
   taskrun.on('start', function() {
+    if (grunt.event.listeners('watch-start').length > 0) {
+      grunt.event.emit('watch-start');
+    }
+
     Object.keys(changedFiles).forEach(function(filepath) {
       // Log which file has changed, and how.
       grunt.log.ok('File "' + filepath + '" ' + changedFiles[filepath] + '.');
@@ -40,6 +44,10 @@ module.exports = function(grunt) {
 
   // When task runner has ended
   taskrun.on('end', function(time) {
+    if (grunt.event.listeners('watch-end').length > 0) {
+      grunt.event.emit('watch-end');
+    }
+
     if (time > 0) {
       dateFormat(time);
     }

--- a/test/fixtures/events/Gruntfile.js
+++ b/test/fixtures/events/Gruntfile.js
@@ -67,4 +67,12 @@ module.exports = function(grunt) {
     }
   });
 
+  grunt.event.on('watch-start', function() {
+    grunt.log.writeln('watch started');
+  });
+
+  grunt.event.on('watch-end', function() {
+    grunt.log.writeln('watch ended');
+  });
+
 };

--- a/test/tasks/events_test.js
+++ b/test/tasks/events_test.js
@@ -162,4 +162,21 @@ exports.events = {
       test.done();
     });
   },
+  watchStartEnd: function(test) {
+    test.expect(5);
+    var cwd = path.resolve(fixtures, 'events');
+    var assertWatch = helper.assertTask('watch:all', {cwd: cwd});
+    assertWatch([function() {
+      writeAll(cwd);
+    }], function(result) {
+      result = helper.unixify(result);
+      helper.verboseLog(result);
+      test.ok(/watch started/.test(result), 'event not emitted when watch started');
+      test.ok(/watch ended/.test(result), 'event not emitted when watch ended');
+      test.ok(result.indexOf('watch started') < result.indexOf('watch ended'), 'start event fired after watch event');
+      test.ok(result.indexOf('watch started') < result.indexOf('>> File'), 'watch-started fired late');
+      test.ok(result.indexOf('>> File') < result.indexOf('watch ended'), 'watch-ended fired early');
+      test.done();
+    });
+  }
 };


### PR DESCRIPTION
Adds events for 'watch-start' and 'watch-end'

This allows users to listen for when watch tasks have been started or finished. Example use:

``` js
grunt.event.on('watch-start', function() {
  grunt.log.writeln('Watch tasks are about to be run!');
});

grunt.event.on('watch-end', function() {
  grunt.log.writeln('Watch tasks are finished running!');
});
```

Status: **Opened for visibility**

Reviewers: @tedtate 
JIRA: https://mobify.atlassian.net/browse/RTM-141
Linked PRs: https://github.com/mobify/adaptivejs/pull/135
## Changes
- Added emits in watch.js where the task runner 'start' and 'end' events are.
- Wrote tests for these events firing in the correct order.
- Updated the README to document the new functionality.
## How to test-drive this PR
- Try and listen for the event in grunt, and verify that the event fires at the correct time (see example code above)
